### PR TITLE
fix(clippy): satisfy question_mark on the backoff-loop command arm

### DIFF
--- a/src/device/actor.rs
+++ b/src/device/actor.rs
@@ -626,14 +626,12 @@ impl Device {
                     return None;
                 }
                 cmd_opt = rx.recv() => {
-                    if let Some(cmd) = cmd_opt {
-                        if let DeviceCommand::ConnectNow = cmd { return Some(()) }
-                        debug!("Rejecting command during backoff for device {}", self.inner.id);
-                        cmd.respond(Err(TuyaError::Offline));
-                        self.broadcast_error(ERR_OFFLINE, None);
-                    } else {
-                        return None;
-                    }
+                    // `?` is the sender-dropped exit: no handles left, so stop the actor.
+                    let cmd = cmd_opt?;
+                    if let DeviceCommand::ConnectNow = cmd { return Some(()) }
+                    debug!("Rejecting command during backoff for device {}", self.inner.id);
+                    cmd.respond(Err(TuyaError::Offline));
+                    self.broadcast_error(ERR_OFFLINE, None);
                 }
             }
         }


### PR DESCRIPTION
## What

clippy 1.97 widened `clippy::question_mark` to flag the
`if let Some(_) = .. else { return None }` shape. With `-D warnings`, CI now
fails on `src/device/actor.rs:629` — code unchanged since 0.3.0.

## Why it surfaced now

`ci.yml` uses an unpinned `dtolnay/rust-toolchain@stable`, and master had not
run CI since 2026-07-04 (work has been on `0.4-sansio`). The first run since
then — dependabot's `actions/setup-python` 6→7 PR (#23) — hit the new lint, so
#23 looks broken while the actual breakage is pre-existing and unrelated to it.

#23 goes green once this lands.

## The fix

`?` is the only form the lint accepts (`let-else` is flagged too), so the intent
`sender dropped -> stop the actor` moves into a comment.

No behaviour change.

## Verified locally on stable 1.97.1

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --all-features` — 102 passed, 0 failed

`0.4-sansio` was checked against the same toolchain and is unaffected (clippy
clean, tests green, `riscv32imc`/`thumbv7em` no_std gate builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)